### PR TITLE
#11 아이템 구현: wind 아이템을 먹으면 air jump 개수 충전

### DIFF
--- a/managers/player_manager.gd
+++ b/managers/player_manager.gd
@@ -22,8 +22,13 @@ func init_air_jump_timer():
 	add_child(air_jump_timer)
 
 
-func restore_air_count(value):
-	air_count_change.emit(min(air_count + value, MAX_AIR_COUNT))
+func restore_air_count(value: int):
+	if air_count + value >= MAX_AIR_COUNT:
+		air_count_change.emit(MAX_AIR_COUNT)
+		air_jump_timer.stop()
+		return
+	
+	air_count_change.emit(air_count + value)
 
 
 func can_air_jump() -> bool:

--- a/prefabs/item_spawner/item_spawner.gd
+++ b/prefabs/item_spawner/item_spawner.gd
@@ -1,0 +1,29 @@
+extends Node
+
+@export var item: Array[PackedScene]
+@export var spawn_time: float = 1.5
+
+var MAX_SPAWNED_ITEM_COUNT := 10
+var spawn_timer: Timer = Timer.new()
+
+
+func _ready() -> void:
+	spawn_timer.wait_time = spawn_time
+	spawn_timer.timeout.connect(spawn_item)
+	spawn_timer.one_shot = false
+	add_child(spawn_timer)
+	spawn_timer.start()
+
+
+func spawn_item() -> void:
+	var spawned_item_count = get_tree().get_nodes_in_group('item').size()
+	var can_spawn_item = spawned_item_count < MAX_SPAWNED_ITEM_COUNT && PlayerManager.velocity.y < 0
+	if !can_spawn_item: return
+
+	var random_item = item[randi() % item.size()]
+	var item_instance = random_item.instantiate()
+	# 아이템 생성 위치는 임시로 이렇게 작성
+	var random_x = PlayerManager.position.x + randf_range(-10, 10)
+	var random_y = PlayerManager.position.y - randf_range(100, 200)
+	item_instance.position = Vector2(random_x, random_y)
+	add_child(item_instance)

--- a/prefabs/player/player.tscn
+++ b/prefabs/player/player.tscn
@@ -46,7 +46,6 @@ _data = {
 radius = 8.06226
 
 [node name="Player" type="CharacterBody2D"]
-collision_layer = 1073741824
 collision_mask = 536870912
 script = ExtResource("1_xo2jn")
 

--- a/prefabs/wind/wind.gd
+++ b/prefabs/wind/wind.gd
@@ -8,7 +8,8 @@ func _ready() -> void:
 
 
 func _on_body_entered(_body: Node2D) -> void:
-	print("item entered")
+	PlayerManager.restore_air_count(1)
+	queue_free()
 
 func _on_screen_exited() -> void:
 	if position.y > PlayerManager.position.y:

--- a/prefabs/wind/wind.gd
+++ b/prefabs/wind/wind.gd
@@ -1,0 +1,15 @@
+extends Area2D
+
+@onready var visible_on_screen_notifier_2d: VisibleOnScreenNotifier2D = $VisibleOnScreenNotifier2D
+
+func _ready() -> void:
+	visible_on_screen_notifier_2d.screen_exited.connect(_on_screen_exited)
+	body_entered.connect(_on_body_entered)
+
+
+func _on_body_entered(_body: Node2D) -> void:
+	print("item entered")
+
+func _on_screen_exited() -> void:
+	if position.y > PlayerManager.position.y:
+		queue_free()

--- a/prefabs/wind/wind.tscn
+++ b/prefabs/wind/wind.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=3 uid="uid://ceg5t28yq0k4j"]
+
+[ext_resource type="Texture2D" uid="uid://dfhybq3l8u1q6" path="res://prefabs/main_hud/wind.png" id="1_n6xi6"]
+[ext_resource type="Script" path="res://prefabs/wind/wind.gd" id="1_upvc0"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_vqdgw"]
+radius = 5.0
+
+[node name="Wind" type="Area2D"]
+collision_layer = 0
+script = ExtResource("1_upvc0")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(0.45, 0.45)
+texture = ExtResource("1_n6xi6")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_vqdgw")
+
+[node name="VisibleOnScreenNotifier2D" type="VisibleOnScreenNotifier2D" parent="." groups=["item"]]
+scale = Vector2(0.5, 0.5)

--- a/test_main_doo.tscn
+++ b/test_main_doo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://baegkoc4y4m70"]
+[gd_scene load_steps=11 format=3 uid="uid://baegkoc4y4m70"]
 
 [ext_resource type="Script" path="res://addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd" id="1_2t00c"]
 [ext_resource type="Texture2D" uid="uid://bpcfive2f5e7w" path="res://assets/sky-bg.png" id="1_sgqly"]
@@ -7,6 +7,8 @@
 [ext_resource type="Script" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="3_1p4cp"]
 [ext_resource type="PackedScene" uid="uid://c7s2nc7vy2sro" path="res://prefabs/player/player.tscn" id="3_t8ypo"]
 [ext_resource type="PackedScene" uid="uid://msugb25k5nsm" path="res://prefabs/main_hud/main_hud.tscn" id="7_dj6ty"]
+[ext_resource type="PackedScene" uid="uid://ceg5t28yq0k4j" path="res://prefabs/wind/wind.tscn" id="8_xvj7y"]
+[ext_resource type="Script" path="res://prefabs/item_spawner/item_spawner.gd" id="9_147af"]
 
 [sub_resource type="Resource" id="Resource_ly4sr"]
 script = ExtResource("3_1p4cp")
@@ -61,5 +63,10 @@ texture = ExtResource("2_fem52")
 
 [node name="Player" parent="." instance=ExtResource("3_t8ypo")]
 scale = Vector2(0.35, 0.35)
+JUMP_SPEED = -150
 
 [node name="MainHud" parent="." instance=ExtResource("7_dj6ty")]
+
+[node name="ItemSpawner" type="Node" parent="."]
+script = ExtResource("9_147af")
+item = Array[PackedScene]([ExtResource("8_xvj7y")])


### PR DESCRIPTION
- #11 

## 작업 내용

@ChanhuiSeok의 멋진 씬 생성 로직을 고대로 가져와서 작업해봤습니다 ㅎㅎ 

1. 아이템 씬 및 기능 추가
> wind 아이템을 추가했슴다~ 이 아이템을 먹으면 바람 개수가 하나 충전되고, 만약 최대 개수라면 쿨타임을 초기화해주도록 했어여

2. 아이템 생성기 추가
> 아이템이 여러 개(2개???) 가 될 예정이라 item_spawner 노드를 추가해 여기서 PackedScene 리스트를 받아서 랜덤하게 아이템 인스턴스들을 관리할 수 있도록 했습니당
>
> 랜덤하게 생성하는 위치는 아직 어떻게할지 정해지지 않은 것 같아서, 간단하게 현재 플레이어 위치를 기준으로 랜덤 값을 계산하도록 했슴돠~

## 데모
- 쿨타임을 조정하면 난이도가 적절해질 것 같음
- 아이템 크기도 필요한 경우 조절해도 될 것 같음(지금은 테스트해볼라고 약간 크게 만들어놓긴함)

https://github.com/user-attachments/assets/8c35103d-7b70-49e4-8fbf-395e9986b030


